### PR TITLE
Fix spelling mistake causing plugin to not run

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
      rules: {
          'no-reassigned-consts': require('./rules/no-reassigned-consts')
      },
-     rulseConfig: {
+     rulesConfig: {
          'no-reassigned-consts': [2, {'constNameMatch': '^[A-Z0-9_]+$'}]
      }
  };


### PR DESCRIPTION
Minor spelling mistake caused the plugin to not run when installed.
